### PR TITLE
Verilator support

### DIFF
--- a/build/verilator_build.sh
+++ b/build/verilator_build.sh
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
-verilator -cc -exe ../top_level.cpp ../sendrecv_cpp.cpp --top-module communicator ../sendrecv_sv.sv -Wno-fatal
-make -j -C obj_dir -f Vcommunicator.mk Vcommunicator CXX=mpic++ LINK=mpic++
+
+
+verilator --trace -cc -exe ../top_mpi_tb.cpp --top-module top_mpi_tb ../metro_mpi_pkg.sv ../sender.sv ../receiver.sv ../top_mpi_tb.sv -Wno-fatal
+
+make -j -C obj_dir -f Vtop_mpi_tb.mk Vtop_mpi_tb CXX=mpic++ LINK=mpic++
+
+obj_dir/Vtop_mpi_tb
+
+gtkwave my_top.vcd metro_mpi.gtkw
+

--- a/fake_node_mpi.sv
+++ b/fake_node_mpi.sv
@@ -1,0 +1,105 @@
+import metro_mpi_pkg::*;
+
+module fake_node_mpi (
+    input  logic            clk_i,
+    input  logic            rstn_i,
+    
+    input  int              rank_i,
+    input  int              origin_i,
+    input  int              dest_i
+
+    // MPI based
+    //input  logic            yummy_i,
+    //input  logic            valid_i,
+    //input  logic [63:0]     data_i,
+
+    //output logic [63:0]     data_o,
+    //output logic            valid_o
+    
+    //output logic            yummy_o
+);
+    //import "DPI-C" function longint unsigned receive(int origin);
+    //import "DPI-C" function longint unsigned mpi_send_data(longint unsigned message, int valid, int dest, int cred, int rank);
+    //import "DPI-C" function longint unsigned mpi_receive_data(longint unsigned message, int valid, int dest, int cred, int rank);
+
+    import "DPI-C" function void mpi_send_yummy(byte unsigned valid, int dest, int rank);
+    import "DPI-C" function byte unsigned mpi_receive_yummy(int origin);
+
+    import "DPI-C" function longint unsigned mpi_receive_data(int origin);
+    import "DPI-C" function byte unsigned mpi_get_valid();
+    import "DPI-C" function void mpi_send_data(longint unsigned data, byte unsigned valid, int dest, int rank);
+
+    byte unsigned message;
+
+    logic [63:0] buffer_data_in, buffer_data_yummy_out;
+    
+    logic [7:0] buffer_yummy_in, valid_data_int, valid_data_in;
+
+    //logic valid_yummy_in;
+    logic valid_yummy_out;
+    //logic valid_data_out;
+    //logic valid_data_in;
+
+    // Instance that receives data and sends yummy
+    receiver_mpi rcv(.clk_i(clk_i),
+                    .rstn_i(rstn_i),
+
+                    .rank_i(rank_i),
+
+                    .valid_i(valid_data_in[0]),
+                    .data_i(buffer_data_in),
+                    
+                    .data_o(buffer_data_yummy_out),
+                    .yummy_o(valid_yummy_out));
+    
+    //assign valid_data_out  = 0;
+
+    // default values
+    //assign data_o = 'h0;
+    //assign valid_o = 'h0;
+    //assign yummy_o = 'h0;
+
+    always_ff @(posedge clk_i, negedge rstn_i) begin
+        if (~rstn_i) begin
+            $display("[SV] reset fake node");
+            //valid_yummy_in  <= 1'b0;
+            valid_data_in   <= 'h0;
+            buffer_data_in  <= 'h0;
+            buffer_yummy_in <= 'h0;
+            valid_data_int  <= 'h0;
+        end
+        else begin
+            if (rank_i==0) begin
+                $display("[SV] Start Cycle Fake Node ");
+            
+                // first we send data
+                //if (valid_data_out) begin
+                //$display("[SV] Sending");
+                //valid_data_int <= {7'b0, 1'b1};
+                //mpi_send_data(1, 1, origin_i, rank_i);
+                //end else begin
+                //    mpi_send_data(1, 1, origin_i, 0, rank_i);
+                //end
+
+                // Now we send yummy
+                $display("[SV] Handling yummy out");
+                message <= {7'b0, valid_yummy_out};
+                //$display("Yummy valid: %b", message);
+                mpi_send_yummy(message, dest_i, rank_i);
+                
+
+                // Now we listen for data receive
+                $display("[SV] Receiving data");
+                buffer_data_in <= mpi_receive_data(origin_i);
+                valid_data_in  <= mpi_get_valid();
+                
+
+                // Now we listen for yummy receive
+                /*$display("handling yummy in");
+                buffer_yummy_in <= mpi_receive_yummy(origin_i);
+                valid_yummy_in <= buffer_yummy_in[0];*/
+            end
+            
+        end
+    end 
+endmodule

--- a/metro_mpi_pkg.sv
+++ b/metro_mpi_pkg.sv
@@ -1,0 +1,18 @@
+
+package metro_mpi_pkg;
+
+parameter CREDIT_WIDTH = 3;
+
+//typedef logic [63:0]  reg64_t;
+
+
+/*typedef enum logic [1:0] {
+    ENUM1  = 2'b00,
+    ENUM2  = 2'b01,
+    ENUM3  = 2'b10,
+    ENUM3  = 2'b11
+} enum_name;    // Enum*/
+
+
+
+endpackage

--- a/receiver.sv
+++ b/receiver.sv
@@ -1,0 +1,83 @@
+import metro_mpi_pkg::*;
+
+module receiver (
+    input  logic            clk_i,
+    input  logic            rstn_i,
+    input  logic            valid_i,
+    input  logic [63:0]     data_i,
+    input  int              origin_i,
+    
+    output logic [63:0]     data_o,
+    output logic            yummy_o
+);
+    //import "DPI-C" function longint unsigned receive(int origin);
+    //import "DPI-C" function longint unsigned snd_sig(longint unsigned message, int dest, int cred, int rank);
+
+    logic [CREDIT_WIDTH-1:0][63:0] buffer;
+
+    logic [63:0] data_to_store, data_out_int;
+    
+    logic [CREDIT_WIDTH-1:0] credit_q, credit_d, num_q, num_d, cnt_q, cnt_d;
+
+    logic yummy_int, write_enable;
+
+    assign yummy_o  = yummy_int;
+    assign data_o   = data_out_int;
+        
+    always_comb begin
+        yummy_int     = 1'b0;
+        data_out_int  = 64'b0;
+        data_to_store = 64'b0;
+        write_enable  = 1'b0;
+        
+        if (valid_i && (credit_q != 0)) begin
+            //buffer_next = receive(origin);
+            data_to_store = data_i;
+            write_enable = 1'b1;
+            cnt_d = 5;
+            $display("credit_next: %h", credit_d);
+        end
+        else if (valid_i && (credit_q == 0)) begin
+            $display("ERROR: credits 0 and valid anyways");
+        end
+
+       /* if (cnt_q != 0) begin
+            cnt_d = cnt_q -1;
+        end else begin
+            cnt_d = cnt_q;
+        end*/
+
+        if (num_q > 0 ) begin
+            data_out_int = buffer[0];
+            yummy_int = 1'b1;
+            $display("data_out: %h", data_out_int);
+        end
+
+        //snd_sig()
+    end
+
+    always_comb begin 
+        num_d = num_q +{2'b0,valid_i} - {2'b0,yummy_int};
+        credit_d = credit_q -{2'b0,valid_i} + {2'b0,yummy_int};
+    end
+
+    always_ff @(posedge clk_i, negedge rstn_i) begin
+        if (~rstn_i) begin
+            $display("reset receiver");
+            credit_q <= 1;
+            num_q <= 0;
+            for (int i = 0; i <= CREDIT_WIDTH-1; i++) begin
+                buffer[i] <= 64'b0; 
+            end
+        end
+        else begin
+            credit_q <= credit_d;
+            num_q    <= num_d;
+            cnt_q    <= cnt_d;
+            if (write_enable) begin
+                buffer[0] <= data_to_store;
+            end
+            
+        end
+    end 
+endmodule

--- a/receiver_mpi.sv
+++ b/receiver_mpi.sv
@@ -1,0 +1,89 @@
+import metro_mpi_pkg::*;
+
+module receiver_mpi (
+    input  logic            clk_i,
+    input  logic            rstn_i,
+    
+    input  int              rank_i,
+    input  int              origin_i,
+
+    input  logic            valid_i,
+    input  logic [63:0]     data_i,
+    
+    output logic [63:0]     data_o,
+    output logic            yummy_o
+);
+    //import "DPI-C" function longint unsigned receive(int origin);
+    //import "DPI-C" function longint unsigned snd_sig(longint unsigned message, int dest, int cred, int rank);
+
+    logic [CREDIT_WIDTH-1:0][63:0] buffer;
+
+    logic [63:0] data_to_store, data_out_int;
+    
+    logic [CREDIT_WIDTH-1:0] credit_q, credit_d, num_q, num_d;//, cnt_q, cnt_d;
+
+    logic yummy_int, write_enable;
+
+    assign yummy_o  = yummy_int;
+    assign data_o   = data_out_int;
+        
+    always_comb begin
+        yummy_int     = 1'b0;
+        data_out_int  = 64'b0;
+        data_to_store = 64'b0;
+        write_enable  = 1'b0;
+
+        if (rank_i == 3) begin
+        
+            if (valid_i && (credit_q != 0)) begin
+                //buffer_next = receive(origin);
+                data_to_store = data_i;
+                write_enable = 1'b1;
+                //cnt_d = 5;
+                $display("credit_next: %h", credit_d);
+            end
+            else if (valid_i && (credit_q == 0)) begin
+                $display("ERROR: credits 0 and valid anyways");
+            end
+
+        /* if (cnt_q != 0) begin
+                cnt_d = cnt_q -1;
+            end else begin
+                cnt_d = cnt_q;
+            end*/
+
+            if (num_q > 0 ) begin
+                data_out_int = buffer[0];
+                yummy_int = 1'b1;
+                $display("data_out: %h", data_out_int);
+            end
+        end
+
+        //snd_sig()
+    end
+
+    always_comb begin 
+        num_d = num_q +{2'b0,valid_i} - {2'b0,yummy_int};
+        credit_d = credit_q -{2'b0,valid_i} + {2'b0,yummy_int};
+    end
+
+    always_ff @(posedge clk_i, negedge rstn_i) begin
+        if (~rstn_i) begin
+            //$display("reset receiver");
+            credit_q <= 1;
+            num_q <= 0;
+            for (int i = 0; i <= CREDIT_WIDTH-1; i++) begin
+                buffer[i] <= 64'b0; 
+            end
+        end
+        else begin
+            credit_q <= credit_d;
+            num_q    <= num_d;
+            //cnt_q    <= cnt_d;
+            if (write_enable) begin
+                buffer[0] <= data_to_store;
+            end
+            
+        end
+    end 
+endmodule

--- a/receiver_mpi.sv
+++ b/receiver_mpi.sv
@@ -13,48 +13,45 @@ module receiver_mpi (
     output logic [63:0]     data_o,
     output logic            yummy_o
 );
-    //import "DPI-C" function longint unsigned receive(int origin);
-    //import "DPI-C" function longint unsigned snd_sig(longint unsigned message, int dest, int cred, int rank);
+    import "DPI-C" function longint unsigned receive(int origin);
+    import "DPI-C" function longint unsigned mpi_send_yummy(longint unsigned message, int valid, int dest, int cred, int rank);
 
     logic [CREDIT_WIDTH-1:0][63:0] buffer;
 
-    logic [63:0] data_to_store, data_out_int;
+    logic valid_yummy, valid_data;
+
+    logic [63:0] data_to_store, data_out_int, buffer_next;
     
-    logic [CREDIT_WIDTH-1:0] credit_q, credit_d, num_q, num_d;//, cnt_q, cnt_d;
+    logic [CREDIT_WIDTH-1:0] credit_q, credit_d, num_q, num_d;
 
     logic yummy_int, write_enable;
 
     assign yummy_o  = yummy_int;
     assign data_o   = data_out_int;
         
+
+    assign yummy_int = num_q > 0;
+
     always_comb begin
         yummy_int     = 1'b0;
         data_out_int  = 64'b0;
         data_to_store = 64'b0;
         write_enable  = 1'b0;
 
-        if (rank_i == 3) begin
+        if (rank_i == 0) begin
         
-            if (valid_i && (credit_q != 0)) begin
-                //buffer_next = receive(origin);
+            /*if (valid_i && (credit_q != 0)) begin
+                buffer_next = receive(origin);
                 data_to_store = data_i;
                 write_enable = 1'b1;
-                //cnt_d = 5;
                 $display("credit_next: %h", credit_d);
             end
             else if (valid_i && (credit_q == 0)) begin
                 $display("ERROR: credits 0 and valid anyways");
-            end
-
-        /* if (cnt_q != 0) begin
-                cnt_d = cnt_q -1;
-            end else begin
-                cnt_d = cnt_q;
             end*/
 
-            if (num_q > 0 ) begin
+            if (valid_yummy) begin
                 data_out_int = buffer[0];
-                yummy_int = 1'b1;
                 $display("data_out: %h", data_out_int);
             end
         end
@@ -63,8 +60,8 @@ module receiver_mpi (
     end
 
     always_comb begin 
-        num_d = num_q +{2'b0,valid_i} - {2'b0,yummy_int};
-        credit_d = credit_q -{2'b0,valid_i} + {2'b0,yummy_int};
+        num_d = num_q +{2'b0,valid_i} - {2'b0,valid_yummy};
+        credit_d = credit_q -{2'b0,valid_i} + {2'b0,valid_yummy};
     end
 
     always_ff @(posedge clk_i, negedge rstn_i) begin
@@ -72,18 +69,35 @@ module receiver_mpi (
             //$display("reset receiver");
             credit_q <= 1;
             num_q <= 0;
+            valid_yummy <= 1'b0;
             for (int i = 0; i <= CREDIT_WIDTH-1; i++) begin
                 buffer[i] <= 64'b0; 
             end
         end
         else begin
-            credit_q <= credit_d;
-            num_q    <= num_d;
-            //cnt_q    <= cnt_d;
-            if (write_enable) begin
-                buffer[0] <= data_to_store;
+            if (rank_i == 0) begin
+                $display("[RCV SV] Start cycle wait for ");
+                buffer_next = receive(origin_i);
+                if (buffer_next == 1) begin
+                    valid_data = 1'b1;
+                end else begin
+                    valid_data = 1'b0;
+                end
+                if (valid_yummy) begin
+                    mpi_send_yummy(1, 1, origin_i, 0, rank_i);
+                end else begin
+                    mpi_send_yummy(0, 0, origin_i, 0, rank_i);
+                end
+                credit_q <= credit_d;
+                num_q    <= num_d;
+                //cnt_q    <= cnt_d;
+                if (write_enable) begin
+                    buffer[0] <= data_to_store;
+                    valid_yummy <= 1'b1;
+                end else begin
+                    valid_yummy <= 1'b0;
+                end
             end
-            
         end
     end 
 endmodule

--- a/receiver_mpi.sv
+++ b/receiver_mpi.sv
@@ -5,7 +5,7 @@ module receiver_mpi (
     input  logic            rstn_i,
     
     input  int              rank_i,
-    input  int              origin_i,
+    //input  int              origin_i,
 
     input  logic            valid_i,
     input  logic [63:0]     data_i,
@@ -13,8 +13,8 @@ module receiver_mpi (
     output logic [63:0]     data_o,
     output logic            yummy_o
 );
-    import "DPI-C" function longint unsigned receive(int origin);
-    import "DPI-C" function longint unsigned mpi_send_yummy(longint unsigned message, int valid, int dest, int cred, int rank);
+    //import "DPI-C" function longint unsigned receive(int origin);
+    //import "DPI-C" function longint unsigned mpi_send_yummy(longint unsigned message, int valid, int dest, int cred, int rank);
 
     logic [CREDIT_WIDTH-1:0][63:0] buffer;
 
@@ -24,34 +24,37 @@ module receiver_mpi (
     
     logic [CREDIT_WIDTH-1:0] credit_q, credit_d, num_q, num_d;
 
+    logic [1:0] cnt_q, cnt_d;
+
     logic yummy_int, write_enable;
 
-    assign yummy_o  = yummy_int;
+    assign yummy_o  = (num_q == 'h03);
     assign data_o   = data_out_int;
         
 
-    assign yummy_int = num_q > 0;
+    //assign yummy_int = num_q > 0;
 
     always_comb begin
-        yummy_int     = 1'b0;
+        //yummy_int     = 1'b0;
         data_out_int  = 64'b0;
         data_to_store = 64'b0;
         write_enable  = 1'b0;
 
         if (rank_i == 0) begin
         
-            /*if (valid_i && (credit_q != 0)) begin
-                buffer_next = receive(origin);
+            if (valid_i && (credit_q != 0)) begin
+                //buffer_next = receive(origin);
                 data_to_store = data_i;
                 write_enable = 1'b1;
                 $display("credit_next: %h", credit_d);
             end
             else if (valid_i && (credit_q == 0)) begin
                 $display("ERROR: credits 0 and valid anyways");
-            end*/
+            end
 
-            if (valid_yummy) begin
+            if (num_q == 'h03) begin
                 data_out_int = buffer[0];
+                //yummy_int = 1'b1;
                 $display("data_out: %h", data_out_int);
             end
         end
@@ -62,6 +65,7 @@ module receiver_mpi (
     always_comb begin 
         num_d = num_q +{2'b0,valid_i} - {2'b0,valid_yummy};
         credit_d = credit_q -{2'b0,valid_i} + {2'b0,valid_yummy};
+        cnt_d = cnt_q + 1;
     end
 
     always_ff @(posedge clk_i, negedge rstn_i) begin
@@ -70,14 +74,15 @@ module receiver_mpi (
             credit_q <= 1;
             num_q <= 0;
             valid_yummy <= 1'b0;
+            cnt_q <= 'h0;
             for (int i = 0; i <= CREDIT_WIDTH-1; i++) begin
                 buffer[i] <= 64'b0; 
             end
         end
         else begin
             if (rank_i == 0) begin
-                $display("[RCV SV] Start cycle wait for ");
-                buffer_next = receive(origin_i);
+                $display("[RCV SV] Start cycle Receiver ");
+                /*buffer_next = receive(origin_i);
                 if (buffer_next == 1) begin
                     valid_data = 1'b1;
                 end else begin
@@ -87,17 +92,16 @@ module receiver_mpi (
                     mpi_send_yummy(1, 1, origin_i, 0, rank_i);
                 end else begin
                     mpi_send_yummy(0, 0, origin_i, 0, rank_i);
-                end
+                end*/
                 credit_q <= credit_d;
                 num_q    <= num_d;
-                //cnt_q    <= cnt_d;
+                cnt_q    <= cnt_d;
                 if (write_enable) begin
-                    buffer[0] <= data_to_store;
-                    valid_yummy <= 1'b1;
+                    buffer[num_q] <= data_to_store;
                 end else begin
-                    valid_yummy <= 1'b0;
+                    buffer[num_q] <= buffer[num_q];
                 end
             end
-        end
+    end
     end 
 endmodule

--- a/sender.sv
+++ b/sender.sv
@@ -1,0 +1,52 @@
+import metro_mpi_pkg::*;
+
+module sender (
+    input  logic            clk_i,
+    input  logic            rstn_i,
+    input  int              origin_i,
+    input  logic            yummy_i,
+
+    output logic [63:0]     data_o,
+    output logic            valid_o
+);
+
+    //import "DPI-C" function longint unsigned receive(int origin);
+    //import "DPI-C" function longint unsigned snd(longint unsigned message, int dest, int cred, int rank);
+
+
+    logic [CREDIT_WIDTH-1:0] credit_q, credit_d;
+    logic [63:0] default_data;
+
+    // Logic credits
+    always_ff @(posedge clk_i, negedge rstn_i) begin
+        if (~rstn_i) begin
+            credit_q <= 1; // Initial assignment
+            default_data <= 64'hcafe_cafe_cafe_cafe;
+        end
+        else begin
+            credit_q <= credit_d;
+            default_data <= default_data + {61'b0,credit_d}; 
+        end
+    end
+
+    always_comb begin
+        valid_o   = 1'b0;
+        data_o    = 64'h0;
+        credit_d  = credit_q +{2'b0,yummy_i};
+
+        // Credit management sending
+        if ((credit_q != 0) & rstn_i) begin
+            valid_o   = 1'b1;
+            data_o    = default_data;
+            credit_d  = credit_q +{2'b0,yummy_i} - {2'b0,valid_o};
+            // /$display("sending from %d to %d", rnk, dest);
+            //snd(data_out, dest, 1, rnk);
+            $display("sender has %d credits", credit_q);
+        end
+        // Print logic
+        if (yummy_i) begin  //should it be else if??
+            $display("incrementing sender cred");
+        end
+    end
+
+endmodule

--- a/sender_mpi.sv
+++ b/sender_mpi.sv
@@ -3,6 +3,7 @@ import metro_mpi_pkg::*;
 module sender_mpi (
     input  logic            clk_i,
     input  logic            rstn_i,
+    
     input  int              dest_i,
     input  int              rank_i,
     input  logic            yummy_i,

--- a/sender_mpi.sv
+++ b/sender_mpi.sv
@@ -1,0 +1,66 @@
+import metro_mpi_pkg::*;
+
+module sender_mpi (
+    input  logic            clk_i,
+    input  logic            rstn_i,
+    input  int              dest_i,
+    input  int              rank_i,
+    input  logic            yummy_i,
+
+    output logic [63:0]     data_o,
+    output logic            valid_o
+);
+
+    import "DPI-C" function longint unsigned receive_async(int origin);
+    import "DPI-C" function longint unsigned receive(int origin);
+    import "DPI-C" function int checkPendingMessages();
+    import "DPI-C" function void snd(longint unsigned message, int dest, int cred, int rank);
+
+
+    logic [CREDIT_WIDTH-1:0] credit_q, credit_d;
+    logic [63:0] default_data;
+
+    // Logic credits
+    always_ff @(posedge clk_i, negedge rstn_i) begin
+        if (~rstn_i) begin
+            credit_q <= 1; // Initial assignment
+            default_data <= 64'hcafe_cafe_cafe_cafe;
+        end
+        else begin
+            credit_q <= credit_d;// +{2'b0,yummy_i} -{2'b0,valid_o};
+            default_data <= default_data + {63'b0,valid_o};
+            if (valid_o) begin
+                int credit = {29'b0,credit_q};
+                $display("sending from %d to %d", rank_i, dest_i);
+                snd(data_o, dest_i, credit, rank_i);
+                receive(1);
+            end
+            /*if (checkPendingMessages() == 1) begin
+                $display("received yummy");
+            end*/
+        end
+    end
+
+    always_comb begin
+        valid_o   = 1'b0;
+        data_o    = 64'h0;
+        credit_d  = credit_q;// +{2'b0,yummy_i};
+        if (rank_i == 0) begin
+            // Credit management sending
+            if ((credit_q != 0) & rstn_i) begin
+                valid_o   = 1'b1;
+                data_o    = default_data;
+                credit_d  = credit_q - 1;
+                //snd(data_o, dest_i, unsigned'(credit_q), rank_i);
+                //$display("sending from %d to %d", rank_i, dest_i);
+                //$display("sender has %d credits", credit_q);
+            end
+            // Print logic
+            else if (yummy_i) begin  //should it be else if??
+                //$display("incrementing sender credits");
+                credit_d  = credit_q + 1;
+            end
+        end
+    end
+
+endmodule

--- a/sendrecv_cpp.cpp
+++ b/sendrecv_cpp.cpp
@@ -3,20 +3,95 @@
 
 using namespace std;
 
+unsigned long long message_async;
+MPI_Status status_async;
+MPI_Request request_async;
+
 extern "C" void initialize(){
     MPI_Init(NULL, NULL);
     cout << "initializing" << endl;
+}
+
+
+extern "C" unsigned long long receive_async(int origin){
+    unsigned long long message;
+    int message_len = 1;
+    //MPI_Status status;
+    cout << "Receive Async from: " << origin << endl;
+    MPI_Irecv(&message_async, message_len, MPI_UNSIGNED_LONG_LONG, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &request_async);
+    
+    //cout << "message: " << std::hex << message << endl;
+    return message;
 }
 
 extern "C" unsigned long long receive(int origin){
     unsigned long long message;
     int message_len = 1;
     MPI_Status status;
-    cout << "origin: " << origin << endl;
+    cout << "Reciving Blockking origin: " << origin << endl;
     MPI_Recv(&message, message_len, MPI_UNSIGNED_LONG_LONG, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
     
-    cout << "message: " << message << endl;
+    cout << "signal: " << message << endl;
     return message;
+}
+
+/*extern "C" unsigned long long receive_async(int origin, int tag){
+    unsigned long long message;
+    int message_len = 1;
+    //MPI_Status status;
+    cout << "Receive Async from: " << origin << endl;
+    MPI_Irecv(&message_async, message_len, MPI_UNSIGNED_LONG_LONG, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &request_async);
+    
+    //cout << "message: " << std::hex << message << endl;
+    return message;
+}*/
+
+extern "C" int getMessageAsync(int origin, int tag){
+    int flag;
+    cout << "Waiting message " << endl;
+    flag = MPI_Wait(&request_async,&status_async);
+    return flag;
+}
+
+
+extern "C" int waitMessageAsync(int origin, int tag){
+    int flag;
+    cout << "Getting message Probe: " << endl;
+    flag = MPI_Probe(origin, tag, MPI_COMM_WORLD, &status_async);
+    return flag;
+}
+
+extern "C" int checkPendingMessages(){
+    int flag;
+    MPI_Test(&request_async, &flag, &status_async);
+    cout << "Checking async message: " << flag << endl;
+    return flag;
+}
+
+extern "C" void snd(unsigned long long message, int dest, int cred, int rank){
+    int message_len = 1;
+    cout << "sending " << std::hex << message << " to " << dest << endl;
+    MPI_Send(&message, message_len, MPI_UNSIGNED_LONG_LONG, dest, cred, MPI_COMM_WORLD);
+}
+
+
+
+/*extern "C" unsigned long long receive_async(int origin){
+    unsigned long long message;
+    int message_len = 1;
+    //MPI_Status status;
+    cout << "Receive Async from: " << origin << endl;
+    MPI_Irecv(&message_async, message_len, MPI_UNSIGNED_LONG_LONG, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &request_async);
+    
+    //cout << "message: " << std::hex << message << endl;
+    return message;
+}
+
+extern "C" int checkPendingMessages(){
+    int flag;
+    MPI_Test(&request_async, &flag, &status_async);
+    cout << "Checking async message: " << flag << endl;
+    return flag;
 }
 
 extern "C" unsigned long long receive_sig(int origin){
@@ -24,23 +99,29 @@ extern "C" unsigned long long receive_sig(int origin){
     int message_len = 1;
     MPI_Status status;
     cout << "origin: " << origin << endl;
-    MPI_Recv(&message, message_len, MPI_UNSIGNED_INT, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+    MPI_Recv(&message, message_len, MPI_UNSIGNED, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
     
     cout << "signal: " << message << endl;
     return message;
 }
 
+extern "C" void send(unsigned long long message, int dest, int cred, int rank){
+    int message_len = 1;
+    cout << "sending " << std::hex << message << " to " << dest << endl;
+    MPI_Send(&message, message_len, MPI_UNSIGNED_LONG_LONG, dest, rank, MPI_COMM_WORLD);
+}
+
 extern "C" void snd(unsigned long long message, int dest, int rank){
     int message_len = 1;
-    cout << "sending " << message << " to " << dest << endl;
+    cout << "sending " << std::hex << message << " to " << dest << endl;
     MPI_Send(&message, message_len, MPI_UNSIGNED_LONG_LONG, dest, rank, MPI_COMM_WORLD);
 }
 
 extern "C" void snd_sig(int message, int dest, int rank){
     int message_len = 1;
     cout << "sending " << message << " to " << dest << endl;
-    MPI_Send(&message, message_len, MPI_UNSIGNED_INT, dest, rank, MPI_COMM_WORLD);
-}
+    MPI_Send(&message, message_len, MPI_UNSIGNED, dest, rank, MPI_COMM_WORLD);
+}*/
 
 extern "C" int getRank(){
     int rank;

--- a/sendrecv_cpp.cpp
+++ b/sendrecv_cpp.cpp
@@ -28,10 +28,21 @@ extern "C" unsigned long long receive(int origin){
     unsigned long long message;
     int message_len = 1;
     MPI_Status status;
-    cout << "Reciving Blockking origin: " << origin << endl;
+    cout << "[DPI CPP] Reciving Blockking origin: " << origin << endl << std::flush;
     MPI_Recv(&message, message_len, MPI_UNSIGNED_LONG_LONG, origin, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
     
-    cout << "signal: " << message << endl;
+    cout << "[DPI CPP] Message Received: " << message << endl << std::flush;
+    return message;
+}
+
+extern "C" unsigned long long receiveYummy(int origin){
+    unsigned long long message;
+    int message_len = 1;
+    MPI_Status status;
+    cout << "[DPI CPP] Reciving Blockking origin: " << origin << endl << std::flush;
+    MPI_Recv(&message, message_len, MPI_UNSIGNED_LONG_LONG, origin, 0, MPI_COMM_WORLD, &status);
+    
+    cout << "signal: " << message << endl << std::flush;
     return message;
 }
 
@@ -70,7 +81,25 @@ extern "C" int checkPendingMessages(){
 
 extern "C" void snd(unsigned long long message, int dest, int cred, int rank){
     int message_len = 1;
-    cout << "sending " << std::hex << message << " to " << dest << endl;
+    cout << "[DPI CPP] Sending " << std::hex << message << " to " << dest << endl;
+    MPI_Send(&message, message_len, MPI_UNSIGNED_LONG_LONG, dest, cred, MPI_COMM_WORLD);
+}
+extern "C" void mpi_send_yummy(unsigned long long message, int valid, int dest, int cred, int rank){
+    int message_len = 1;
+    cout << "[DPI CPP] Sending YUMMY " << std::hex << message << " to " << dest << endl << std::flush;
+    MPI_Send(&message, message_len, MPI_UNSIGNED_LONG_LONG, dest, 0, MPI_COMM_WORLD);
+}
+/*extern "C" void mpi_send_yummy(unsigned long long message, int valid, int dest, int cred, int rank){
+    int message_len = 2;
+    unsigned long long message_to_send[2];
+    message_to_send[0] = valid;
+    message_to_send[1] = message;
+    cout << "Sending YUMMY " << std::hex << message << " to " << dest << endl;
+    MPI_Send(&message_to_send, message_len, MPI_UNSIGNED_LONG_LONG, dest, cred, MPI_COMM_WORLD);
+}*/
+extern "C" void mpi_send_data(unsigned long long message, int dest, int cred, int rank){
+    int message_len = 1;
+    cout << "Sending DATA " << std::hex << message << " to " << dest << endl;
     MPI_Send(&message, message_len, MPI_UNSIGNED_LONG_LONG, dest, cred, MPI_COMM_WORLD);
 }
 

--- a/sendrecv_sv.sv
+++ b/sendrecv_sv.sv
@@ -32,7 +32,7 @@ module receiver (
             yumi = 1'b1;
             $display("data_out: %h", data_out);
         end
-        snd()
+        //snd_sig()
     end
 
     always @(posedge clk) begin

--- a/sendrecv_testbench.sv
+++ b/sendrecv_testbench.sv
@@ -22,8 +22,8 @@ module creditmpi_tb();
     wire valid, yumi;
     wire [63:0] data;
     wire [63:0] recv_data;
-    receiver rcv(.clk(clk), .rst_n(rst_n_recv), .valid(valid), .origin(data_origin), .data_out(recv_data), .yumi(yumi));
-    sender snd(.clk(clk), .rst_n(rst_n_send), .dest(dest), .rnk(rank), .valid(valid), .yumi(yumi));
+    //receiver rcv(.clk(clk), .rst_n(rst_n_recv), .valid(valid), .origin(data_origin), .data_out(recv_data), .yumi(yumi));
+    //sender snd(.clk(clk), .rst_n(rst_n_send), .dest(dest), .rnk(rank), .valid(valid), .yumi(yumi));
 
     initial begin
         rst_n_send = 0;

--- a/top_level.cpp
+++ b/top_level.cpp
@@ -156,17 +156,10 @@ int main(int argc, char **argv, char **env) {
     reset_and_init();
 
 //    while (!Verilated::gotFinish()) { tick(); }
-    std::cout << "tick" << std::endl;
-    tick();
-    
-    top->eval();
-    std::cout << "eval" << std::endl;
-    tick();
-    std::cout << "tick" << std::endl;
-    tick();
-    std::cout << "tick" << std::endl;
-    top->eval();
-    std::cout << "eval" << std::endl;
+    for (int i = 0; i < 10; i++) {
+        std::cout << "tick" << std::endl;
+        tick();
+    }
     
     #ifdef VERILATOR_VCD
     std::cout << "Trace done" << std::endl;

--- a/top_mpi_tb.cpp
+++ b/top_mpi_tb.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv, char **env) {
 
 //    while (!Verilated::gotFinish()) { tick(); }
     for (int i = 0; i < 10; i++) {
-        std::cout << rank << " tick" << std::endl;
+        std::cout << "Cycle: " << std::dec << main_time << std::endl;
         tick();
     }
     top->finalize_i = 1;

--- a/top_mpi_tb.cpp
+++ b/top_mpi_tb.cpp
@@ -80,7 +80,8 @@ int main(int argc, char **argv, char **env) {
     std::cout << "RANK: " << top->rank_o << std::endl << std::flush;
     
     top->trace (tfp, 99);
-    std::string tracename ("my_top"+std::to_string(top->rank_o)+".vcd");
+    std::string rank = std::to_string(top->rank_o);
+    std::string tracename ("my_top"+rank+".vcd");
     const char *cstr = tracename.c_str();
     tfp->open(cstr);
     //tfp->open ("my_top.vcd");
@@ -90,8 +91,8 @@ int main(int argc, char **argv, char **env) {
     reset_and_init();
 
 //    while (!Verilated::gotFinish()) { tick(); }
-    for (int i = 0; i < 1000; i++) {
-        std::cout << "tick" << std::endl;
+    for (int i = 0; i < 10; i++) {
+        std::cout << rank << " tick" << std::endl;
         tick();
     }
     top->finalize_i = 1;

--- a/top_mpi_tb.cpp
+++ b/top_mpi_tb.cpp
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2018 Princeton University
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Princeton University nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY PRINCETON UNIVERSITY "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL PRINCETON UNIVERSITY BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "Vtop_mpi_tb.h"
+#include "verilated.h"
+#include <iostream>
+#include "verilated_vcd_c.h"
+
+uint64_t main_time = 0; // Current simulation time
+uint64_t clk = 0;
+Vtop_mpi_tb* top;
+VerilatedVcdC* tfp;
+// This is a 64-bit integer to reduce wrap over issues and
+double sc_time_stamp () { // Called by $time in Verilog
+    return main_time; // converts to double, to match
+// what SystemC does
+}
+
+void tick() {
+    top->clk_i = !top->clk_i;
+    main_time += 1;
+    top->eval();
+    tfp->dump(main_time);
+    
+    top->clk_i = !top->clk_i;
+    main_time += 1;
+    top->eval();
+    tfp->dump(main_time);
+}
+
+void reset_and_init() {
+    
+    //std::cout << "Reset" << std::endl;
+    top->rstn_i = 0;
+    top->finalize_i = 0;
+    for (int i = 0; i < 5;i++) {
+        tick();
+    }
+    top->rstn_i = 1;
+    //std::cout << "Reset finish" << std::endl;
+
+}
+
+int main(int argc, char **argv, char **env) {
+    //std::cout << "Started" << std::endl << std::flush;
+    Verilated::commandArgs(argc, argv);
+    
+    top = new Vtop_mpi_tb;
+    
+    //std::cout << "Vtop_mpi_tb created" << std::endl << std::flush;
+    
+    Verilated::traceEverOn(true);
+    
+    tfp = new VerilatedVcdC;
+
+    top->rstn_i = 0;
+    top->eval();
+
+    std::cout << "RANK: " << top->rank_o << std::endl << std::flush;
+    
+    top->trace (tfp, 99);
+    std::string tracename ("my_top"+std::to_string(top->rank_o)+".vcd");
+    const char *cstr = tracename.c_str();
+    tfp->open(cstr);
+    //tfp->open ("my_top.vcd");
+    
+    //Verilated::debug(1);
+    //#endif
+    reset_and_init();
+
+//    while (!Verilated::gotFinish()) { tick(); }
+    for (int i = 0; i < 1000; i++) {
+        std::cout << "tick" << std::endl;
+        tick();
+    }
+    top->finalize_i = 1;
+    tick();
+
+    //std::cout << "Trace done" << std::endl;
+    tfp->close();
+
+    delete top;
+    exit(0);
+}

--- a/top_mpi_tb.sv
+++ b/top_mpi_tb.sv
@@ -1,0 +1,94 @@
+module top_mpi_tb(
+    input  logic clk_i,
+    input  logic rstn_i,
+    input  logic finalize_i,
+    output int   rank_o,
+    output logic valid_o
+);
+    import "DPI-C" function void initialize();
+    import "DPI-C" function void finalize();
+    import "DPI-C" function int getRank();
+    import "DPI-C" function int getSize();
+
+    //import "DPI-C" function longint unsigned receive(int origin);
+    import "DPI-C" function int getMessageAsync(int origin, int tag);
+    import "DPI-C" function int checkPendingMessages();
+    import "DPI-C" function longint unsigned receive_async(int origin);
+    import "DPI-C" function void snd(longint unsigned message, int dest, int cred, int rank);
+    
+    /*reg clk = 0;
+    initial begin
+        forever begin
+            clk = ~clk;
+            #10;
+        end
+	end*/
+
+    logic yummy_rcv_snd, valid_snd_rcv;
+    
+    logic [63:0] data_snd_rcv, data_out;
+
+    int dest;
+
+    int rank, rank_receiver;
+    int size;
+
+    logic [63:0] buffer_next;
+
+    /*receiver_mpi rcv(.clk_i(clk_i),
+                 .rstn_i(rstn_i),
+                 .origin_i(0),
+                 .rank_i(rank),
+                 .valid_i(valid_snd_rcv),
+                 .data_i(data_snd_rcv),
+
+                 .data_o(data_out),
+                 .yummy_o(yummy_rcv_snd));*/
+
+    sender_mpi   snder(.clk_i(clk_i),
+                 .rstn_i(rstn_i),
+                 
+                 .dest_i(dest),
+                 .rank_i(rank),
+                 
+                 //.yummy_i(yummy_rcv_snd),
+                 .yummy_i(0),
+                 .valid_o(valid_snd_rcv),
+                 .data_o(data_snd_rcv));
+
+    assign rank_o = rank;
+    assign valid_o = valid_snd_rcv;
+
+    initial begin
+        initialize();
+        rank = getRank();
+        size = getSize();
+        $display("size: %d", size);
+        $display("rank: %d", rank);
+        if(rank == 0) begin
+            dest = 1;
+        end else begin
+            dest = 0;
+            buffer_next = receive_async(0);
+
+        end
+    end
+
+    always_ff @( posedge clk_i ) begin
+        if (finalize_i) begin
+            finalize();
+        end
+        else if (rank == 1) begin
+            if (checkPendingMessages() == 1) begin
+                $display("Message received");
+                //$display("%d ", getMessageAsync(1, 0));
+                $display("message obtained");
+                snd(1,dest,1,rank);
+                //finalize();
+                buffer_next = receive_async(0);
+            end
+        end
+    end
+
+endmodule
+

--- a/top_tb.sv
+++ b/top_tb.sv
@@ -1,0 +1,27 @@
+module top_tb(
+    input logic clk_i,
+    input logic rstn_i
+);
+    logic yummy_rcv_snd, valid_snd_rcv;
+    
+    logic [63:0] data_snd_rcv, data_out;
+
+    receiver rcv(.clk_i(clk_i),
+                 .rstn_i(rstn_i),
+                 .origin_i(0),
+                 .valid_i(valid_snd_rcv),
+                 .data_i(data_snd_rcv),
+
+                 .data_o(data_out),
+                 .yummy_o(yummy_rcv_snd));
+
+    sender   snd(.clk_i(clk_i),
+                 .rstn_i(rstn_i),
+                 .origin_i(0),
+                 .yummy_i(yummy_rcv_snd),
+                 //.yummy_i(yummy_i_fake),
+                 .valid_o(valid_snd_rcv),
+                 .data_o(data_snd_rcv));
+
+endmodule
+


### PR DESCRIPTION
This branch represents my current work (not finished) on supporting verilator.

However, we can start a discussion on some topics

## MPI sync
At the start of each cycle, we make the sends and the receives (synchronous) with two different tags. The tag is important because we have different types of messages

e.g.
send(valid,data,tag=0)
send(valid_yummy, tag=1)
receive(valid,data, tag=0)
receive(valid_yummy,tag=1)
start cycle --> do work

The current plan is to do it in #delays in Verilog for VCS and explore making it in C++ for Verilator

## MPI Messages
- There are two types of messages to be sent: valid&data and yummy.

### Yummy
- This message is easier and only has 1 bit signal that represents the valid can be mapped to a char, int, longint...
- I don't know if makes a difference using int or char in performance. Since this is easily changeable, we can change it in the future...
- We can use the rest of the bits to point the directions is coming from (N,W,E,S) or the channel, or other necessary details that may be necessary.

## Valid&data
-  Valid has 1 bit and data 64 bits in System Verilog, in MPI we can have a struct that has two longints or one longint and one char/int/short/longint.
- e.g.
typedef struct {
    unsigned char valid;
    unsigned long long data;
} mpi_data_t;

Again, the types can be easily changed for valid.